### PR TITLE
chore: publish npm 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "unplugin-iconify",
+  "name": "@waset/unplugin-iconify",
   "type": "module",
-  "version": "0.1.0",
+  "version": "0.0.1",
   "packageManager": "pnpm@9.12.2",
   "description": "",
   "author": "waset <waset@foxmail.com>",
   "license": "MIT",
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/waset/unplugin-iconify#readme",
   "repository": {
     "type": "git",

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,7 +4,7 @@
     "dev": "nodemon -w '../src/**/*.ts' -e .ts -x vite"
   },
   "devDependencies": {
-    "unplugin-iconify": "workspaces:*",
+    "@waset/unplugin-iconify": "latest",
     "vite": "^5.4.2",
     "vite-plugin-inspect": "^0.8.7"
   }

--- a/playground/package.json
+++ b/playground/package.json
@@ -4,6 +4,7 @@
     "dev": "nodemon -w '../src/**/*.ts' -e .ts -x vite"
   },
   "devDependencies": {
+    "unplugin-iconify": "workspaces:*",
     "vite": "^5.4.2",
     "vite-plugin-inspect": "^0.8.7"
   }

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,10 +1,16 @@
 import { defineConfig } from 'vite'
 import Inspect from 'vite-plugin-inspect'
-import Unplugin from '../src/vite'
+/**
+ *  package.json
+ *
+ *  "unplugin-iconify": "workspaces:*",
+ */
+// import Iconify from '../src/vite'
+import Iconify from '@waset/unplugin-iconify/vite'
 
 export default defineConfig({
   plugins: [
     Inspect(),
-    Unplugin(),
+    Iconify(),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
 
   playground:
     devDependencies:
+      '@waset/unplugin-iconify':
+        specifier: latest
+        version: 0.0.1(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.2(@types/node@22.7.6)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))
       vite:
         specifier: ^5.4.2
         version: 5.4.2(@types/node@22.7.6)(terser@5.36.0)
@@ -1189,6 +1192,32 @@ packages:
 
   '@vue/shared@3.4.38':
     resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
+
+  '@waset/unplugin-iconify@0.0.1':
+    resolution: {integrity: sha512-vHuaymoZug+Gc85ibGo9CYJ0IAS5Ct368ABDUZo1GKl3k/OoyLIlc1sS11Q9G5mdtyORVglhIjSWD2g3I2FwPQ==}
+    peerDependencies:
+      '@farmfe/core': '>=1'
+      '@nuxt/kit': ^3
+      '@nuxt/schema': ^3
+      esbuild: '*'
+      rollup: ^3
+      vite: '>=3'
+      webpack: ^4 || ^5
+    peerDependenciesMeta:
+      '@farmfe/core':
+        optional: true
+      '@nuxt/kit':
+        optional: true
+      '@nuxt/schema':
+        optional: true
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
 
   '@webassemblyjs/ast@1.12.1':
     resolution: {integrity: sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==}
@@ -4931,6 +4960,20 @@ snapshots:
       '@vue/shared': 3.4.38
 
   '@vue/shared@3.4.38': {}
+
+  '@waset/unplugin-iconify@0.0.1(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.2(@types/node@22.7.6)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))':
+    dependencies:
+      unplugin: 1.14.1(webpack-sources@3.2.3)
+    optionalDependencies:
+      '@farmfe/core': 1.3.29
+      '@nuxt/kit': 3.13.2(rollup@4.24.0)(webpack-sources@3.2.3)
+      '@nuxt/schema': 3.13.2(rollup@4.24.0)(webpack-sources@3.2.3)
+      esbuild: 0.24.0
+      rollup: 4.24.0
+      vite: 5.4.2(@types/node@22.7.6)(terser@5.36.0)
+      webpack: 5.95.0(esbuild@0.24.0)
+    transitivePeerDependencies:
+      - webpack-sources
 
   '@webassemblyjs/ast@1.12.1':
     dependencies:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新特性**
	- 包名已更改为“@waset/unplugin-iconify”，以反映命名空间调整。
	- 新增“publishConfig”字段，指定包为公共访问。
	- 在开发依赖中添加了“unplugin-iconify”和“@waset/unplugin-iconify”依赖项。

- **错误修复**
	- 修正了“pubilc”字段的拼写错误，应该为“public”。
  
- **其他变更**
	- 更新了`vite.config.ts`中的插件导入，使用`Iconify()`替代`Unplugin()`。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->