### PR TITLE
feat: 优化转换配置、逻辑; 适配 vscode 插件; 适配 unocss ;

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,107 @@
 # unplugin-iconify
 
-[![NPM version](https://img.shields.io/npm/v/unplugin-iconify?color=a1b858&label=)](https://www.npmjs.com/package/unplugin-iconify)
-
-Iconify template for [unplugin](https://github.com/unjs/unplugin).
+[![NPM version](https://img.shields.io/npm/v/@waset/unplugin-iconify?color=blue)](https://www.npmjs.com/package/@waset/unplugin-iconify)
 
 ## Install
 
 ```bash
-npm i -D unplugin-iconify
+pnpm i -D @waset/unplugin-iconify
 ```
+
+## Configuration
+
+```ts
+Iconify({
+  convert: {
+    icon: './icons',
+    svg: {
+      path: './icons',
+      noColor: true,
+    },
+    suffix: {
+      path: './icons',
+      noColor: true,
+      suffix: 'color',
+    },
+  },
+  output: 'dist/icons', // @default 'node_modules/.unplugin-iconify'
+  iconifyIntelliSense: true, // @default false
+})
+```
+
+- 如果开启 `iconifyIntelliSense`，将自动创建/更新 `.vscode/settings.json` 文件，用于 VSCode 插件 [Iconify IntelliSense](https://marketplace.visualstudio.com/items?itemName=antfu.iconify)
+
+- `convert` 选项用于将图标转换为图标集，请查看 `src/core/types.ts` 获取更多类型信息。
+
+## Usage
+
+<details>
+<summary>Vite</summary>
+
+```ts
+// vite.config.ts
+import Iconify from '@waset/unplugin-iconify/vite'
+
+export default defineConfig({
+  plugins: [
+    Iconify({
+      // ...
+    })
+  ],
+})
+```
+</details>
+
+<details>
+<summary>Nuxt</summary>
+
+```ts
+// nuxt.config.ts
+import { defineNuxtConfig } from 'nuxt/config'
+
+// https://nuxt.com/docs/api/configuration/nuxt-config
+export default defineNuxtConfig({
+  modules: [
+    // ...
+    '@waset/unplugin-iconify/nuxt'
+  ],
+  Iconify: {
+    // ...
+  },
+})
+```
+</details>
+
+<details>
+<summary>unocss</summary>
+
+```ts
+// uno.config.ts
+import { UnocssLoader } from '@waset/unplugin-iconify/loader'
+import { defineConfig, presetIcons } from 'unocss'
+
+export default defineConfig({
+  presets: [
+    // ...
+    presetIcons({
+      scale: 1.2,
+      warn: true,
+      extraProperties: {
+        'display': 'inline-block',
+        'vertical-align': 'middle',
+      },
+      collections: {
+        ...UnocssLoader(),
+      },
+    }),
+  ],
+  // ...
+})
+```
+</details>
+
+## Thanks
+
+- [unplugin](https://github.com/unjs/unplugin)
+- [unplugin/unplugin-icons](https://github.com/unplugin/unplugin-icons)
+- [unocss](https://github.com/unocss/unocss)

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "eslint": "^9.12.0",
     "esno": "^4.8.0",
     "fast-glob": "^3.3.2",
+    "jsonc-parser": "^3.3.1",
     "nodemon": "^3.1.7",
     "rollup": "^4.24.0",
     "tsup": "^8.3.0",

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "description": "",
   "author": "waset <waset@foxmail.com>",
   "license": "MIT",
-  "publishConfig": {
-    "access": "public"
-  },
   "homepage": "https://github.com/waset/unplugin-iconify#readme",
   "repository": {
     "type": "git",
@@ -129,6 +126,7 @@
     }
   },
   "dependencies": {
+    "jsonc-parser": "^3.3.1",
     "unplugin": "^1.14.1"
   },
   "devDependencies": {
@@ -142,7 +140,6 @@
     "eslint": "^9.12.0",
     "esno": "^4.8.0",
     "fast-glob": "^3.3.2",
-    "jsonc-parser": "^3.3.1",
     "nodemon": "^3.1.7",
     "rollup": "^4.24.0",
     "tsup": "^8.3.0",
@@ -151,5 +148,8 @@
     "vitest": "^2.1.3",
     "webpack": "^5.95.0"
   },
-  "pubilc": true
+  "pubilc": true,
+  "publishConfig": {
+    "access": "public"
+  }
 }

--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -1,28 +1,19 @@
 import { defineConfig } from 'vite'
 import Inspect from 'vite-plugin-inspect'
-/**
- *  package.json
- *
- *  "unplugin-iconify": "workspaces:*",
- */
-// import Iconify from '../src/vite'
-import Iconify from '@waset/unplugin-iconify/vite'
+import Iconify from '../src/vite'
 
 export default defineConfig({
   plugins: [
     Inspect(),
     Iconify({
-      convert: [
-        {
+      convert: {
+        svg: {
           path: './icons',
-          prefix: 'icon',
           noColor: true,
         },
-        {
-          path: './icons',
-          prefix: 'icon-color',
-        },
-      ],
-    }) as any,
+        icon: './icons',
+      },
+      iconifyIntelliSense: true,
+    }),
   ],
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       nodemon:
         specifier: ^3.1.7
         version: 3.1.7
@@ -74,7 +77,7 @@ importers:
     devDependencies:
       '@waset/unplugin-iconify':
         specifier: latest
-        version: 0.0.2(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.9(@types/node@22.7.8)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))
+        version: 0.1.0(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.9(@types/node@22.7.8)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))
       vite:
         specifier: ^5.4.2
         version: 5.4.9(@types/node@22.7.8)(terser@5.36.0)
@@ -1215,14 +1218,14 @@ packages:
   '@vue/shared@3.4.38':
     resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
 
-  '@waset/unplugin-iconify@0.0.2':
-    resolution: {integrity: sha512-yDGGbzJxVVPFjtRO8W2GDkN7fdy2BHTR66HkwtCSQUvgEDx/3pzwCd2Mo9yjWvq2pQlz3wQIZCb2eXG9TooWMg==}
+  '@waset/unplugin-iconify@0.1.0':
+    resolution: {integrity: sha512-CiWfr0VCYTH1qtt74vwW5M23RlB7Agse1lUoblGz1aUzAxVl28qlwbLItgvWbruvpeqlF6matFzORxe/rGLUgw==}
     peerDependencies:
       '@farmfe/core': '>=1'
       '@nuxt/kit': ^3
       '@nuxt/schema': ^3
       esbuild: '*'
-      rollup: ^3
+      rollup: ^3 || ^4.0.0
       vite: '>=3'
       webpack: ^4 || ^5
     peerDependenciesMeta:
@@ -5141,7 +5144,7 @@ snapshots:
 
   '@vue/shared@3.4.38': {}
 
-  '@waset/unplugin-iconify@0.0.2(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.9(@types/node@22.7.8)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))':
+  '@waset/unplugin-iconify@0.1.0(@farmfe/core@1.3.29)(@nuxt/kit@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(@nuxt/schema@3.13.2(rollup@4.24.0)(webpack-sources@3.2.3))(esbuild@0.24.0)(rollup@4.24.0)(vite@5.4.9(@types/node@22.7.8)(terser@5.36.0))(webpack-sources@3.2.3)(webpack@5.95.0(esbuild@0.24.0))':
     dependencies:
       unplugin: 1.14.1(webpack-sources@3.2.3)
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       esbuild:
         specifier: '*'
         version: 0.23.1
+      jsonc-parser:
+        specifier: ^3.3.1
+        version: 3.3.1
       unplugin:
         specifier: ^1.14.1
         version: 1.14.1(webpack-sources@3.2.3)
@@ -48,9 +51,6 @@ importers:
       fast-glob:
         specifier: ^3.3.2
         version: 3.3.2
-      jsonc-parser:
-        specifier: ^3.3.1
-        version: 3.3.1
       nodemon:
         specifier: ^3.1.7
         version: 3.1.7

--- a/src/core/convert.ts
+++ b/src/core/convert.ts
@@ -26,11 +26,11 @@ export async function Generateds(options: Required<Options>): Promise<void> {
 /**
  * 转换单个图表集
  * @param name 图表集名称
- * @param stting 图表集路径或转换配置
+ * @param setting 图表集路径或转换配置
  * @param output 输出路径
  */
-export async function Generated(name: string, stting: string | Convert, output: string): Promise<void> {
-  const convert = typeof stting === 'string' ? { path: stting } : { ...stting }
+export async function Generated(name: string, setting: string | Convert, output: string): Promise<void> {
+  const convert = typeof setting === 'string' ? { path: setting } : { ...setting }
   const { path, noColor, suffix } = convert
 
   if (!existsSync(path)) {

--- a/src/core/convert.ts
+++ b/src/core/convert.ts
@@ -7,6 +7,10 @@ import { importDirectory } from '@iconify/tools/lib/import/directory'
 import { runSVGO } from '@iconify/tools/lib/optimise/svgo'
 import { cleanupSVG } from '@iconify/tools/lib/svg/cleanup'
 
+const SUCCESS_COLOR = '\x1B[32m'
+const RESET_COLOR = '\x1B[0m'
+const NUMBER_COLOR = '\x1B[31m'
+
 /**
  * 转换多个图表集
  * @param options 转换配置
@@ -15,12 +19,13 @@ export async function Generateds(options: Required<Options>): Promise<void> {
   if (!options.convert) {
     throw new Error('No convert option')
   }
+
   for (const key in options.convert) {
     await Generated(key, options.convert[key], options.output)
   }
 
   // eslint-disable-next-line no-console
-  console.log(`\n\x1B[32m Converted \x1B[0m \x1B[31m ${Object.keys(options.convert).length} \x1B[0m \x1B[32m collections \x1B[0m`)
+  console.log(`\n${SUCCESS_COLOR} Converted${RESET_COLOR} ${NUMBER_COLOR}${Object.keys(options.convert).length}${RESET_COLOR} ${SUCCESS_COLOR}collections${RESET_COLOR}`)
 }
 
 /**
@@ -95,5 +100,5 @@ export async function Generated(name: string, setting: string | Convert, output:
   writeFileSync(`${out_dir}/${iconSet.prefix}.json`, exported, 'utf8')
 
   // eslint-disable-next-line no-console
-  console.log(`\x1B[32m Imported ${name}: \x1B[0m \x1B[31m ${Object.keys(iconSet.entries).length} \x1B[0m`)
+  console.log(`${SUCCESS_COLOR} Imported ${name}: ${RESET_COLOR}${NUMBER_COLOR}${Object.keys(iconSet.entries).length}${RESET_COLOR}`)
 }

--- a/src/core/convert.ts
+++ b/src/core/convert.ts
@@ -1,25 +1,53 @@
-import type { Convert } from './types'
+import type { Convert, Options } from './types'
 import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { cwd } from 'node:process'
 import { isEmptyColor, parseColors } from '@iconify/tools/lib/colors/parse'
-import { importDirectory } from '@iconify/tools/lib/import/directory'
+import { importDirectorySync } from '@iconify/tools/lib/import/directory'
 import { runSVGO } from '@iconify/tools/lib/optimise/svgo'
-
 import { cleanupSVG } from '@iconify/tools/lib/svg/cleanup'
 
-export async function Generated(option: Convert): Promise<void> {
-  const { path, out, prefix, noColor } = option
+/**
+ * 转换多个图表集
+ * @param options 转换配置
+ */
+export async function Generateds(options: Required<Options>): Promise<void> {
+  if (!options.convert) {
+    throw new Error('No convert option')
+  }
+  for (const key in options.convert) {
+    await Generated(key, options.convert[key], options.output)
+  }
+
+  // eslint-disable-next-line no-console
+  console.log(`\n\x1B[32m Converted \x1B[0m \x1B[31m ${Object.keys(options.convert).length} \x1B[0m \x1B[32m collections \x1B[0m`)
+}
+
+/**
+ * 转换单个图表集
+ * @param name 图表集名称
+ * @param stting 图表集路径或转换配置
+ * @param output 输出路径
+ */
+export async function Generated(name: string, stting: string | Convert, output: string): Promise<void> {
+  const convert = typeof stting === 'string' ? { path: stting } : { ...stting }
+  const { path, noColor, suffix } = convert
+
   if (!existsSync(path)) {
     throw new Error(`Path ${path} does not exist`)
   }
+
   // Import icons
-  const iconSet = await importDirectory(path, {
-    prefix,
+  const iconSet = importDirectorySync(path, {
+    prefix: name,
+    includeSubDirs: true,
+    keyword: (_, name) => {
+      return `${name}${(suffix) ? `-${suffix}` : ''}`
+    },
   })
 
   // Validate, clean up, fix palette and optimise
-  await iconSet.forEach(async (name, type) => {
+  iconSet.forEach(async (name, type) => {
     if (type !== 'icon')
       return
 
@@ -58,14 +86,14 @@ export async function Generated(option: Convert): Promise<void> {
   const exported = `${JSON.stringify(iconSet.export(), null, '\t')}\n`
 
   // 构建 manifest 文件路径
-  const srcDir = join(cwd(), out || 'temp/icons')
-  if (!existsSync(srcDir)) {
-    mkdirSync(srcDir, { recursive: true })
+  const out_dir = join(cwd(), output)
+  if (!existsSync(out_dir)) {
+    mkdirSync(out_dir, { recursive: true })
   }
 
   // Save to file
-  writeFileSync(`${srcDir}/${iconSet.prefix}.json`, exported, 'utf8')
+  writeFileSync(`${out_dir}/${iconSet.prefix}.json`, exported, 'utf8')
 
   // eslint-disable-next-line no-console
-  console.log(`\x1B[32m Imported icons: \x1B[0m \x1B[31m ${Object.keys(iconSet.entries).length} \x1B[0m`)
+  console.log(`\x1B[32m Imported ${name}: \x1B[0m \x1B[31m ${Object.keys(iconSet.entries).length} \x1B[0m`)
 }

--- a/src/core/convert.ts
+++ b/src/core/convert.ts
@@ -3,7 +3,7 @@ import { existsSync, mkdirSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { cwd } from 'node:process'
 import { isEmptyColor, parseColors } from '@iconify/tools/lib/colors/parse'
-import { importDirectorySync } from '@iconify/tools/lib/import/directory'
+import { importDirectory } from '@iconify/tools/lib/import/directory'
 import { runSVGO } from '@iconify/tools/lib/optimise/svgo'
 import { cleanupSVG } from '@iconify/tools/lib/svg/cleanup'
 
@@ -38,7 +38,7 @@ export async function Generated(name: string, setting: string | Convert, output:
   }
 
   // Import icons
-  const iconSet = importDirectorySync(path, {
+  const iconSet = await importDirectory(path, {
     prefix: name,
     includeSubDirs: true,
     keyword: (_, name) => {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,110 @@
+import type { Convert, Loaders, Optional, Options } from './types'
+import { getOutputFiles, UnocssLoader } from '../loader'
+import { Generateds } from './convert'
+import { IconifyIntelliSenseSettings } from './vscode'
+
+export class Iconify {
+  /**
+   * 配置
+   */
+  options: Required<Options>
+
+  /**
+   * 默认配置
+   *
+   * @description 统一管理默认值，避免使用 `if` 判断
+   */
+  defaultOptions: Optional<Options> = {
+    output: 'node_modules/.unplugin-iconify',
+    iconifyIntelliSense: false,
+    convert: {},
+  }
+
+  /**
+   * 默认转换配置
+   *
+   * @description 统一管理默认值，避免使用 `if` 判断
+   */
+  defaultConvert: Optional<Convert> = {
+    suffix: '',
+    noColor: false,
+  }
+
+  /**
+   * 构造器
+   * @param options Options
+   */
+  constructor(options: Options) {
+    this.options = { ...this.defaultOptions, ...options }
+    this.setOptions(this.options)
+  }
+
+  /**
+   * 设置配置
+   * @param options Options
+   */
+  private setOptions(options: Required<Options>): void {
+    if (!Object.keys(options.convert).length) {
+      return
+    }
+
+    /**
+     * 处理 convert 配置并设置默认值
+     */
+    for (const key in options.convert) {
+      const value = options.convert[key]
+      if (typeof value === 'string') {
+        options.convert[key] = {
+          path: value,
+          ...this.defaultConvert,
+        }
+      }
+      else if (typeof value === 'object') {
+        options.convert[key] = {
+          ...this.defaultConvert,
+          ...value,
+        }
+      }
+    }
+
+    // 更新配置
+    this.options = options
+  }
+
+  /**
+   * 转换
+   */
+  async toConvert(): Promise<void> {
+    await Generateds(this.options)
+  }
+
+  /**
+   * 生成的 JSON 文件
+   */
+  outputs: string[] = []
+
+  /**
+   * 获取输出文件
+   */
+  async toLoad(): Promise<void> {
+    this.outputs = getOutputFiles(this.options.output)
+  }
+
+  /**
+   * 获取加载器
+   *
+   * @param dir 目录
+   */
+  getLoaders(dir: string = this.options.output): Record<Loaders, any> {
+    return {
+      unocss: UnocssLoader(dir),
+    }
+  }
+
+  /**
+   * 生成 Iconify IntelliSense 配置
+   */
+  async toIntelliSense(): Promise<void> {
+    await IconifyIntelliSenseSettings(this.outputs)
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -75,7 +75,12 @@ export class Iconify {
    * 转换
    */
   async toConvert(): Promise<void> {
-    await Generateds(this.options)
+    try {
+      await Generateds(this.options)
+    }
+    catch (error) {
+      console.error('toConvert 出错了：', error)
+    }
   }
 
   /**
@@ -87,7 +92,12 @@ export class Iconify {
    * 获取输出文件
    */
   async toLoad(): Promise<void> {
-    this.outputs = getOutputFiles(this.options.output)
+    try {
+      this.outputs = getOutputFiles(this.options.output)
+    }
+    catch (error) {
+      console.error('toLoad 出错了：', error)
+    }
   }
 
   /**

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -6,14 +6,12 @@ export interface Convert {
    * 要扫描文件的目录的路径。
    */
   path: string
+
   /**
-   * 生成的类型文件的命名空间前缀。
+   * 生成的类型文件的命名空间后缀。
    */
-  prefix: string
-  /**
-   * 生成的类型文件的输出目录。
-   */
-  out?: string
+  suffix?: string
+
   /**
    * 是否为无色
    */
@@ -26,6 +24,45 @@ export interface Convert {
 export interface Options {
   /**
    * 要转换的图表集
+   *
+   * @example
+   * ```ts
+    convert: {
+      icon: '~/icons',
+      svg: {
+        path: '~/icons',
+        noColor: true,
+      },
+      mixed: {
+        path: '~/icons',
+        suffix: 'mixed',
+      },
+    },
+   *```
    */
-  convert: Convert | Convert[]
+  convert?: Record<string, Convert['path'] | Convert>
+
+  /**
+   * 生成的类型文件的输出目录。
+   *
+   * @default 'node_modules/.unplugin-iconify'
+   */
+  output?: string
+
+  /**
+   * 是否支持 [Iconify IntelliSense](https://marketplace.visualstudio.com/items?itemName=antfu.iconify)
+   * @description 开启后将自动更新 `.vscode/settings.json` 的 `iconify.customCollectionJsonPaths` 配置
+   * @default false
+   */
+  iconifyIntelliSense?: boolean | string
 }
+
+export type Optional<T> = Required<{
+  [K in keyof T as T[K] extends Required<T>[K] ? never : K]: T[K]
+}>
+
+export type Loaders = 'unocss'
+
+export type Awaitable<T> = T | PromiseLike<T>
+export type CustomIconLoader = (name: string) => Awaitable<string | undefined>
+export type CustomIconLoaderMap = Record<string, CustomIconLoader>

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -1,0 +1,57 @@
+import type { FormattingOptions } from 'jsonc-parser'
+import { applyEdits, modify } from 'jsonc-parser'
+
+/**
+ * 更新 json 指定 key 的值
+ * @param content json 文本
+ * @param key key
+ * @param value 新值
+ */
+export function injectJsonc(content: string, key: string, value: any): string | NodeJS.ArrayBufferView {
+  const formatting = detectIndentation(content)
+
+  const edits = modify(
+    content,
+    toArray(key),
+    value,
+    {
+      formattingOptions: {
+        eol: '\n',
+        insertFinalNewline: true,
+        ...formatting,
+      },
+    },
+  )
+
+  const updatedcontent = applyEdits(content, edits)
+
+  return updatedcontent
+}
+
+/**
+ * 检测 json 文本缩进
+ * @param content json 文本
+ * @returns 格式化选项
+ */
+export function detectIndentation(content: string): FormattingOptions {
+  const lines = content.split(/\r?\n/)
+  for (const line of lines) {
+    const match = line.match(/^(\s+)\S/)
+    if (match) {
+      const indent = match[1]
+      return {
+        insertSpaces: indent.includes(' '),
+        tabSize: indent.includes(' ') ? indent.length : 2,
+      }
+    }
+  }
+  return {
+    insertSpaces: true,
+    tabSize: 2,
+  }
+}
+
+export function toArray<T>(array?: T | T[]): T[] {
+  array = array ?? []
+  return Array.isArray(array) ? array : [array]
+}

--- a/src/core/vscode.ts
+++ b/src/core/vscode.ts
@@ -1,0 +1,26 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { cwd } from 'node:process'
+import { injectJsonc } from './utils'
+
+/**
+ * vscode `iconify.customCollectionJsonPaths` 配置
+ * @param jsons json 文件路径
+ */
+export async function IconifyIntelliSenseSettings(jsons: string[]): Promise<void> {
+  const dir = join(cwd(), '.vscode')
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+  const settingPath = join(dir, 'settings.json')
+
+  if (!existsSync(settingPath)) {
+    writeFileSync(settingPath, '{}')
+  }
+
+  const settingText = readFileSync(settingPath, 'utf-8')
+
+  writeFileSync(settingPath, injectJsonc(settingText, 'iconify.customCollectionJsonPaths', jsons), {
+    encoding: 'utf-8',
+  })
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,30 +1,31 @@
 import type { UnpluginFactory } from 'unplugin'
-import type { Convert, Options } from './core/types'
+import type { Options } from './core/types'
 import { createUnplugin } from 'unplugin'
-import { Generated } from './core/convert'
+import { Iconify } from './core'
 
 export const unpluginFactory: UnpluginFactory<Options> = options => ({
   name: 'unplugin-iconify',
   buildStart: async () => {
     /**
-     * 解析配置
+     * 初始化
      */
-    let converts: Convert[] = []
-    if (Array.isArray(options.convert)) {
-      converts = options.convert
-    }
-    else {
-      if (!options.convert) {
-        throw new Error('unplugin-iconify 未正确配置')
-      }
-      converts.push(options.convert)
-    }
+    const handle = new Iconify(options)
+
     /**
-     * 开始转换
+     * 转换图标
      */
-    for (const option of converts) {
-      // 转换
-      await Generated(option)
+    await handle.toConvert()
+
+    /**
+     * 加载器加载图标
+     */
+    const _loaders = handle.getLoaders()
+
+    /**
+     * 生成 Iconify IntelliSense 配置
+     */
+    if (options.iconifyIntelliSense) {
+      await handle.toIntelliSense()
     }
   },
 })
@@ -32,3 +33,4 @@ export const unpluginFactory: UnpluginFactory<Options> = options => ({
 export const unplugin = /* #__PURE__ */ createUnplugin(unpluginFactory)
 
 export default unplugin
+export type { Options } from './core/types'

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,9 +17,9 @@ export const unpluginFactory: UnpluginFactory<Options> = options => ({
     await handle.toConvert()
 
     /**
-     * 加载器加载图标
+     * 加载图标
      */
-    const _loaders = handle.getLoaders()
+    await handle.toLoad()
 
     /**
      * 生成 Iconify IntelliSense 配置

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -1,0 +1,37 @@
+import type { CustomIconLoader } from './core/types'
+import { existsSync, readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { cwd } from 'node:process'
+
+/**
+ * unocss 图标加载器
+ * @param dir 图标目录
+ * @returns unocss 图标配置
+ */
+export function UnocssLoader(dir: string): Record<string, CustomIconLoader> {
+  const jsons = getOutputFiles(dir)
+  const icons: Record<string, CustomIconLoader> = {}
+  jsons.forEach((file) => {
+    const name = file.replace('.json', '')
+    icons[name] = () => JSON.parse(readFileSync(file, 'utf-8'))
+  })
+
+  return icons
+}
+
+/**
+ * 获取所有输出文件
+ */
+export function getOutputFiles(dir: string): string[] {
+  // 构建 manifest 文件路径
+  const srcDir = join(cwd(), dir)
+
+  if (!existsSync(srcDir)) {
+    console.error(`\x1B[31m UnocssLoader: ${srcDir} not exists! \x1B[0m`)
+    return []
+  }
+
+  const files = readdirSync(srcDir).filter(file => file.endsWith('.json'))
+
+  return files.map(file => join(srcDir, file))
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
	- 更新了包名称为 `@waset/unplugin-iconify`，并提供了新的安装命令。
	- 增加了配置选项，支持 `Iconify` 函数的使用，包括 `convert`、`output` 和 `iconifyIntelliSense`。
	- 提供了 Vite、Nuxt 和 Unocss 的使用示例，增强了文档的清晰度。
	- 引入了 `Iconify` 类以集中管理图标转换的配置和功能。
	- 新增了 `IconifyIntelliSenseSettings` 函数以支持 VSCode 的配置。
	- 新增了用于加载自定义图标的功能，支持 Unocss。

- **错误修复**
	- 修正了 `package.json` 中的拼写错误。

- **文档**
	- 更新了 `README.md` 文件，增强了配置和使用部分的说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->