### PR TITLE
fix: publish types entrypoint

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+export type * from './core/types'


### PR DESCRIPTION
## Summary

- add the missing source entry for the documented `@waset/unplugin-iconify/types` export
- re-export the existing public types from `src/core/types.ts`
- let the existing tsup configuration emit the advertised ESM, CommonJS, and declaration files

## Problem

`@waset/unplugin-iconify@1.4.0` advertises `./types` as `./dist/types.js` / `./dist/types.cjs`, but those files are absent from the published tarball. A clean install therefore fails with `ERR_MODULE_NOT_FOUND` for ESM and `MODULE_NOT_FOUND` for CommonJS.

## Validation

- `corepack pnpm build`
- `corepack pnpm lint`
- `corepack pnpm exec vitest run` (1 test passed)
- packed and installed the local tarball in a clean consumer
- `import('@waset/unplugin-iconify/types')` succeeds
- `require('@waset/unplugin-iconify/types')` succeeds
- TypeScript 5.6 resolves `Convert` and `Options` from the subpath with `moduleResolution: NodeNext`

The corrected tarball contains `dist/types.js`, `dist/types.cjs`, `dist/types.d.ts`, and `dist/types.d.cts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **代码重构**
  * 调整内部类型导出结构

<!-- end of auto-generated comment: release notes by coderabbit.ai -->